### PR TITLE
Modernize package build metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = [
+    "setuptools>=64",
+    "setuptools-scm>=8",
+    "wheel",
+    "Cython>=0.29.36",
+    "numpy>=1.20",
+]
+build-backend = "setuptools.build_meta"
+

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,52 @@
 """ecoshard setup.py."""
+import os
+
 import numpy
 from setuptools.extension import Extension
 from setuptools import setup
 
-import os
-print(os.environ['PATH'])
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    cythonize = None
 
 
 LONG_DESCRIPTION = '%s\n\n%s' % (
     open('README.rst').read(),
     open('HISTORY.rst').read())
 
+
+def _source_path(pyx_path):
+    """Return Cython source, or generated C++ when Cython is unavailable."""
+    cpp_path = os.path.splitext(pyx_path)[0] + '.cpp'
+    if cythonize is None and os.path.exists(cpp_path):
+        return cpp_path
+    return pyx_path
+
+
+EXTENSIONS = [
+    Extension(
+        name="ecoshard.geoprocessing.routing.routing",
+        sources=[
+            _source_path("src/ecoshard/geoprocessing/routing/routing.pyx")],
+        include_dirs=[
+            numpy.get_include(),
+            'src/ecoshard/geoprocessing/routing'],
+        language="c++",
+    ),
+    Extension(
+        "ecoshard.geoprocessing.geoprocessing_core",
+        sources=[
+            _source_path('src/ecoshard/geoprocessing/geoprocessing_core.pyx')],
+        include_dirs=[numpy.get_include()],
+        language="c++"
+    ),
+]
+if cythonize is not None:
+    EXTENSIONS = cythonize(EXTENSIONS)
+
 setup(
     name='ecoshard',
-    setup_requires=['setuptools_scm'],
     use_scm_version={'version_scheme': 'post-release',
                      'local_scheme': 'node-and-date'},
     description='EcoShard GIS data',
@@ -47,21 +80,5 @@ setup(
         'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: BSD License'
     ],
-    ext_modules=[
-        Extension(
-            name="ecoshard.geoprocessing.routing.routing",
-            sources=["src/ecoshard/geoprocessing/routing/routing.pyx"],
-            include_dirs=[
-                numpy.get_include(),
-                'src/ecoshard/geoprocessing/routing'],
-            language="c++",
-        ),
-        Extension(
-            "ecoshard.geoprocessing.geoprocessing_core",
-            sources=[
-                'src/ecoshard/geoprocessing/geoprocessing_core.pyx'],
-            include_dirs=[numpy.get_include()],
-            language="c++"
-        ),
-    ]
+    ext_modules=EXTENSIONS,
 )


### PR DESCRIPTION
## Summary
- Add PEP 517 build-system metadata in `pyproject.toml`.
- Move Cython extension setup into an explicit extension list that uses `cythonize` when available.
- Remove legacy `setup_requires` build-egg fetching and the setup-time PATH print.

Closes #40.

## Testing
- `python -m pip wheel --no-deps . -w build\wheelhouse` passed with isolated build dependencies.
- `python -m pip install --no-deps --no-build-isolation --target build\noiso-smoke .` passed in this local checkout using existing generated C++ files.
- `python -c "from osgeo import gdal; print(gdal.VersionInfo())"` failed locally because `osgeo` is not installed in this environment.
- `python -m pytest tests\test_task.py -q` was not run because `pytest` is not installed in this environment.

## Notes
- This keeps GDAL and other runtime geospatial dependencies out of the packaging metadata for now, since those are usually provided by conda/system packages in working environments.
- A clean `--no-build-isolation` install still needs build dependencies such as Cython available unless generated C++ sources are present.