### PR TITLE
Prevent TaskGraph SQLite lock retry convoys

### DIFF
--- a/src/taskgraph/Task.py
+++ b/src/taskgraph/Task.py
@@ -42,6 +42,8 @@ except ImportError:
 LOGGER = logging.getLogger(__name__)
 _MAX_TIMEOUT = 5.0  # amount of time to wait for threads to terminate
 MIN_REPORTING_TIME = 1.0  # minimum time to wait between reports
+_SQLITE_BUSY_TIMEOUT = 60.0
+_SQLITE_OPERATION_LOCK = threading.Lock()
 
 
 def safe_copyfile(src_path, dst_path):
@@ -1763,58 +1765,71 @@ def _execute_sqlite(
     """
     cursor = None
     connection = None
-
-    try:
-        if mode == 'read_only':
-            ro_uri = r'%s?mode=ro' % pathlib.Path(
-                os.path.abspath(database_path)).as_uri()
-            LOGGER.debug(
-                '%s exists: %s', ro_uri, os.path.exists(os.path.abspath(
-                    database_path)))
-            connection = sqlite3.connect(ro_uri, uri=True)
-        elif mode == 'modify':
-            connection = sqlite3.connect(database_path)
-        else:
-            raise ValueError('Unknown mode: %s' % mode)
-
-        if execute == 'execute':
-            if argument_list is None:
-                cursor = connection.execute(sqlite_command)
+    committed = False
+    with _SQLITE_OPERATION_LOCK:
+        try:
+            if mode == 'read_only':
+                ro_uri = r'%s?mode=ro' % pathlib.Path(
+                    os.path.abspath(database_path)).as_uri()
+                LOGGER.debug(
+                    '%s exists: %s', ro_uri, os.path.exists(os.path.abspath(
+                        database_path)))
+                connection = sqlite3.connect(
+                    ro_uri, uri=True, timeout=_SQLITE_BUSY_TIMEOUT)
+            elif mode == 'modify':
+                connection = sqlite3.connect(
+                    database_path, timeout=_SQLITE_BUSY_TIMEOUT)
             else:
-                cursor = connection.execute(sqlite_command, argument_list)
-        elif execute == 'script':
-            cursor = connection.executescript(sqlite_command)
-        else:
-            raise ValueError('Unknown execute mode: %s' % execute)
+                raise ValueError('Unknown mode: %s' % mode)
 
-        result = None
-        payload = None
-        if fetch == 'all':
-            payload = (cursor.fetchall())
-        elif fetch == 'one':
-            payload = (cursor.fetchone())
-        elif fetch is not None:
-            raise ValueError('Unknown fetch mode: %s' % fetch)
-        if payload is not None:
-            result = list(payload)
-        cursor.close()
-        connection.commit()
-        connection.close()
-        cursor = None
-        connection = None
-        return result
-    except sqlite3.OperationalError:
-        LOGGER.exception(
-            f'TaskGraph database at {database_path} might be locked because '
-            f'another process is using it, waiting for a bit of time to try '
-            f'again. The command attempted is "{sqlite_command}"')
-        raise
-    except Exception:
-        LOGGER.exception('Exception on _execute_sqlite: %s', sqlite_command)
-        raise
-    finally:
-        if cursor is not None:
+            connection.execute(
+                'PRAGMA busy_timeout=%d' % int(_SQLITE_BUSY_TIMEOUT * 1000))
+
+            if execute == 'execute':
+                if argument_list is None:
+                    cursor = connection.execute(sqlite_command)
+                else:
+                    cursor = connection.execute(sqlite_command, argument_list)
+            elif execute == 'script':
+                cursor = connection.executescript(sqlite_command)
+            else:
+                raise ValueError('Unknown execute mode: %s' % execute)
+
+            result = None
+            payload = None
+            if fetch == 'all':
+                payload = (cursor.fetchall())
+            elif fetch == 'one':
+                payload = (cursor.fetchone())
+            elif fetch is not None:
+                raise ValueError('Unknown fetch mode: %s' % fetch)
+            if payload is not None:
+                result = list(payload)
             cursor.close()
-        if connection is not None:
-            connection.commit()
-            connection.close()
+            cursor = None
+            if mode == 'modify':
+                connection.commit()
+                committed = True
+            return result
+        except sqlite3.OperationalError:
+            LOGGER.exception(
+                f'TaskGraph database at {database_path} might be locked '
+                f'because another process is using it, waiting for a bit of '
+                f'time to try again. The command attempted is '
+                f'"{sqlite_command}"')
+            raise
+        except Exception:
+            LOGGER.exception('Exception on _execute_sqlite: %s', sqlite_command)
+            raise
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if connection is not None:
+                if mode == 'modify' and not committed:
+                    try:
+                        connection.rollback()
+                    except sqlite3.Error:
+                        LOGGER.debug(
+                            'SQLite rollback failed during cleanup.',
+                            exc_info=True)
+                connection.close()

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,5 +1,6 @@
 """Tests for ecoshard.taskgraph."""
 import hashlib
+import importlib
 import logging
 import logging.handlers
 import multiprocessing
@@ -10,8 +11,10 @@ import re
 import shutil
 import sqlite3
 import tempfile
+import threading
 import time
 import unittest
+import unittest.mock
 
 import retrying
 import ecoshard.taskgraph
@@ -1475,6 +1478,60 @@ class TaskGraphTests(unittest.TestCase):
                         f'unexpected column name {column_name} in '
                         'taskgraph_data ')
             self.assertEqual(len(result), len(expected_column_name_list))
+
+    def test_execute_sqlite_waits_for_transient_read_lock(self):
+        """TaskGraph: test SQLite waits instead of retrying reader locks."""
+        taskgraph_task = importlib.import_module('ecoshard.taskgraph.Task')
+        database_path = os.path.join(
+            self.workspace_dir, ecoshard.taskgraph._TASKGRAPH_DATABASE_FILENAME)
+        taskgraph_task._create_taskgraph_table_schema(database_path)
+
+        blocker_connection = sqlite3.connect(
+            database_path, check_same_thread=False)
+        blocker_connection.execute('BEGIN')
+        blocker_connection.execute('SELECT * FROM taskgraph_data').fetchone()
+
+        release_lock_event = threading.Event()
+
+        def _release_lock():
+            release_lock_event.wait()
+            time.sleep(0.4)
+            blocker_connection.commit()
+            blocker_connection.close()
+
+        release_thread = threading.Thread(target=_release_lock)
+        release_thread.start()
+
+        original_connect = sqlite3.connect
+
+        def _short_default_timeout_connect(*args, **kwargs):
+            """Use a short timeout only when the caller does not set one."""
+            kwargs.setdefault('timeout', 0.1)
+            return original_connect(*args, **kwargs)
+
+        try:
+            release_lock_event.set()
+            with unittest.mock.patch.object(
+                    taskgraph_task.sqlite3, 'connect',
+                    side_effect=_short_default_timeout_connect):
+                with unittest.mock.patch.object(
+                        taskgraph_task.LOGGER, 'exception') as log_exception:
+                    taskgraph_task._execute_sqlite(
+                        'INSERT OR REPLACE INTO taskgraph_data VALUES '
+                        '(?, ?, ?)',
+                        database_path,
+                        mode='modify',
+                        argument_list=(
+                            'transient-lock',
+                            pickle.dumps([]),
+                            pickle.dumps(None)))
+            lock_retry_messages = [
+                call for call in log_exception.call_args_list
+                if 'might be locked' in str(call)]
+            self.assertEqual([], lock_retry_messages)
+        finally:
+            release_lock_event.set()
+            release_thread.join()
 
     def test_terminate_log(self):
         """TaskGraph: test that the logger thread terminates on .join."""


### PR DESCRIPTION
Closes #42

## Summary
- Serialize TaskGraph SQLite operations inside a process so parent executor threads do not stampede the cache database.
- Set an explicit SQLite busy timeout on read and write connections.
- Avoid committing again during cleanup after failed database operations; failed writes now roll back before closing.
- Add a regression test that holds a transient SQLite read lock and verifies `_execute_sqlite` waits instead of logging a lock retry.

## Testing
- `C:\Users\richp\miniforge3\python.exe -m py_compile src\taskgraph\Task.py tests\test_task.py`
- Direct SQLite transient-lock verification script against the patched `src/taskgraph/Task.py`: passed.
- `C:\Users\richp\miniforge3\python.exe -m unittest tests.test_task.TaskGraphTests.test_execute_sqlite_waits_for_transient_read_lock`: not run successfully because the local environment is missing `retrying` before test collection.

## Known Limitations
- This does not address multiple independent `TaskGraph` instances sharing the same cache directory; that should be tracked separately.