### PR TITLE
Allow task arguments to resolve results

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - pytest
   - pip
   - pip:
-      - -e .
+      - -e .[test]

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,22 @@
+name: ecoshard-dev
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - gdal
+  - numpy
+  - scipy
+  - shapely
+  - rtree
+  - psutil
+  - numexpr
+  - requests
+  - retrying
+  - sqlalchemy
+  - boto3
+  - filelock
+  - cython
+  - pytest
+  - pip
+  - pip:
+      - -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,22 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ecoshard"
+description = "EcoShard GIS data"
+readme = "README.rst"
+license = "BSD-3-Clause"
+maintainers = [
+    {name = "Rich Sharp", email = "richpsharp@gmail.com"},
+]
+keywords = ["computing reproduction"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft",
+    "Operating System :: POSIX",
+    "Programming Language :: Python :: 3.7",
+    "License :: OSI Approved :: BSD License",
+]
 dynamic = ["version"]
 dependencies = [
     "boto3",
@@ -30,4 +46,11 @@ dependencies = [
 test = [
     "pytest",
 ]
+
+[project.urls]
+Homepage = "https://github.com/therealspring/ecoshard"
+
+[tool.setuptools_scm]
+version_scheme = "post-release"
+local_scheme = "node-and-date"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "Operating System :: Microsoft",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3.7",
-    "License :: OSI Approved :: BSD License",
 ]
 dynamic = ["version"]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,26 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "ecoshard"
+dynamic = ["version"]
+dependencies = [
+    "boto3",
+    "filelock",
+    "GDAL",
+    "numexpr",
+    "numpy",
+    "psutil",
+    "requests",
+    "retrying",
+    "Rtree",
+    "scipy",
+    "shapely",
+    "SQLAlchemy",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+]
+

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,6 @@ except ImportError:
     cythonize = None
 
 
-LONG_DESCRIPTION = '%s\n\n%s' % (
-    open('README.rst').read(),
-    open('HISTORY.rst').read())
-
-
 def _source_path(pyx_path):
     """Return Cython source, or generated C++ when Cython is unavailable."""
     cpp_path = os.path.splitext(pyx_path)[0] + '.cpp'
@@ -46,14 +41,6 @@ if cythonize is not None:
     EXTENSIONS = cythonize(EXTENSIONS)
 
 setup(
-    name='ecoshard',
-    use_scm_version={'version_scheme': 'post-release',
-                     'local_scheme': 'node-and-date'},
-    description='EcoShard GIS data',
-    long_description=LONG_DESCRIPTION,
-    maintainer='Rich Sharp',
-    maintainer_email='richpsharp@gmail.com',
-    url='https://github.com/therealspring/ecoshard',
     packages=[
         'ecoshard',
         'ecoshard.geoprocessing',
@@ -69,16 +56,5 @@ setup(
     },
     zip_safe=False,
     include_package_data=True,
-    license='BSD',
-    keywords='computing reproduction',
-    classifiers=[
-        'Intended Audience :: Developers',
-        'Natural Language :: English',
-        'Operating System :: MacOS :: MacOS X',
-        'Operating System :: Microsoft',
-        'Operating System :: POSIX',
-        'Programming Language :: Python :: 3.7',
-        'License :: OSI Approved :: BSD License'
-    ],
     ext_modules=EXTENSIONS,
 )

--- a/src/taskgraph/Task.py
+++ b/src/taskgraph/Task.py
@@ -19,6 +19,7 @@ import shutil
 import sqlite3
 import threading
 import time
+import uuid
 
 import retrying
 
@@ -121,6 +122,90 @@ class NonDaemonicPool(multiprocessing.pool.Pool):
 def _null_func():
     """Used when func=None on add_task."""
     return None
+
+
+class TaskRef(object):
+    """Serializable reference to a TaskGraph task.
+
+    A ``TaskRef`` is what worker functions receive when a ``Task`` is passed
+    as an argument to ``TaskGraph.add_task``. It deliberately avoids carrying
+    scheduler-local state such as thread events and worker pools.
+    """
+
+    def __init__(self, task):
+        """Create a reference to ``task``."""
+        self.task_name = task.task_name
+        self._task_id_hash = task._task_id_hash
+        self._target_path_list = tuple(task._target_path_list)
+        self._store_result = task._store_result
+        self._task_reexecution_hash = task._task_reexecution_hash
+        self._task = task
+        self._has_result = False
+        self._result = None
+
+    @property
+    def target_path_list(self):
+        """Return a copy of the referenced task's target paths."""
+        return list(self._target_path_list)
+
+    def get(self, timeout=None):
+        """Return the referenced task result."""
+        if not self._store_result:
+            raise ValueError(
+                'must set `store_result` to True in `add_task` to invoke this '
+                'function')
+        if self._task is not None:
+            return self._task.get(timeout)
+        if self._has_result:
+            return self._result
+        raise RuntimeError(
+            f'Task result for {self.task_name} was not serialized')
+
+    def _scrubbed_signature(self):
+        """Return a stable representation for Task hashing."""
+        return (
+            'task_ref',
+            self._task_id_hash,
+            self._target_path_list,
+            self._store_result)
+
+    def __getstate__(self):
+        """Serialize only portable task reference state."""
+        state = {
+            'task_name': self.task_name,
+            '_task_id_hash': self._task_id_hash,
+            '_target_path_list': self._target_path_list,
+            '_store_result': self._store_result,
+            '_task_reexecution_hash': self._task_reexecution_hash,
+            '_task': None,
+            '_has_result': self._has_result,
+            '_result': self._result,
+        }
+        if self._store_result and self._task is not None:
+            state['_result'] = self._task.get()
+            state['_has_result'] = True
+            state['_task_reexecution_hash'] = self._task._task_reexecution_hash
+        return state
+
+    def __setstate__(self, state):
+        """Restore serialized task reference state."""
+        self.__dict__.update(state)
+
+    def __eq__(self, other):
+        """Return True when ``other`` refers to the same task signature."""
+        return (
+            isinstance(other, self.__class__) and
+            self._task_id_hash == other._task_id_hash)
+
+    def __hash__(self):
+        """Return a stable hash for set/dict membership."""
+        return hash(self._task_id_hash)
+
+    def __repr__(self):
+        """Return a debugging representation of this reference."""
+        return (
+            f'TaskRef(task_name={self.task_name!r}, '
+            f'task_id_hash={self._task_id_hash!r})')
 
 
 def _initialize_logging_to_queue(logging_queue):
@@ -299,6 +384,7 @@ class TaskGraph(object):
             os.makedirs(taskgraph_cache_dir_path, exist_ok=True)
 
         self._taskgraph_name = taskgraph_name
+        self._task_graph_id = uuid.uuid4().hex
 
         self._taskgraph_cache_dir_path = taskgraph_cache_dir_path
 
@@ -640,8 +726,12 @@ class TaskGraph(object):
 
         Args:
             func (callable): target function
-            args (list): argument list for ``func``
-            kwargs (dict): keyword arguments for ``func``
+            args (list): argument list for ``func``. ``Task`` values from
+                this graph are converted to serializable ``TaskRef`` values
+                and automatically added as dependencies.
+            kwargs (dict): keyword arguments for ``func``. ``Task`` values
+                from this graph are converted to serializable ``TaskRef``
+                values and automatically added as dependencies.
             target_path_list (list): if not None, a list of file paths that
                 are expected to be output by ``func``.  If any of these paths
                 don't exist, or their timestamp is earlier than an input
@@ -743,6 +833,15 @@ class TaskGraph(object):
             if func is None:
                 func = _null_func
 
+            dependent_task_list = list(dependent_task_list)
+            args, args_task_list = _replace_task_args_with_refs(
+                args, self._task_graph_id)
+            kwargs, kwargs_task_list = _replace_task_args_with_refs(
+                kwargs, self._task_graph_id)
+            for task in args_task_list + kwargs_task_list:
+                if task not in dependent_task_list:
+                    dependent_task_list.append(task)
+
             # this is a pretty common error to accidentally not pass a
             # Task to the dependent task list.
             if any(not isinstance(task, Task)
@@ -758,7 +857,8 @@ class TaskGraph(object):
                 transient_run, self._worker_pool,
                 self._taskgraph_cache_dir_path, priority, hash_algorithm,
                 copy_duplicate_artifact, store_result,
-                self._task_database_path, self._allow_different_target_paths)
+                self._task_database_path, self._allow_different_target_paths,
+                self._task_graph_id)
 
             self._task_name_map[new_task.task_name] = new_task
             # it may be this task was already created in an earlier call,
@@ -1015,7 +1115,8 @@ class Task(object):
             ignore_path_list, hash_target_files, ignore_directories,
             transient_run, worker_pool, cache_dir, priority, hash_algorithm,
             copy_duplicate_artifact, store_result,
-            task_database_path, allow_different_target_paths):
+            task_database_path, allow_different_target_paths,
+            task_graph_id=None):
         """Make a Task.
 
         Args:
@@ -1081,6 +1182,7 @@ class Task(object):
                 ``result``.
             allow_different_target_paths (bool): if true, raise an error if there is a
                 mismatch on hash/vs file list, used for debugging
+            task_graph_id: id of the owning ``TaskGraph``.
 
         """
         # it is a common error to accidentally pass a non string as to the
@@ -1112,6 +1214,7 @@ class Task(object):
         self._copy_duplicate_artifact = copy_duplicate_artifact
         self._store_result = store_result
         self._allow_different_target_paths = allow_different_target_paths
+        self._task_graph_id = task_graph_id
         self.exception_object = None
 
         # invert the priority since sorting goes smallest to largest and we
@@ -1514,6 +1617,38 @@ class Task(object):
         return self._result
 
 
+def _replace_task_args_with_refs(base_value, task_graph_id):
+    """Replace same-graph ``Task`` instances with ``TaskRef`` instances."""
+    if isinstance(base_value, Task):
+        if base_value._task_graph_id != task_graph_id:
+            raise ValueError(
+                'Task arguments must come from the same TaskGraph as the '
+                'task being added')
+        return TaskRef(base_value), [base_value]
+    if isinstance(base_value, dict):
+        result_dict = {}
+        task_list = []
+        for key, value in base_value.items():
+            replaced_key, key_task_list = _replace_task_args_with_refs(
+                key, task_graph_id)
+            replaced_value, value_task_list = _replace_task_args_with_refs(
+                value, task_graph_id)
+            result_dict[replaced_key] = replaced_value
+            task_list.extend(key_task_list)
+            task_list.extend(value_task_list)
+        return result_dict, task_list
+    if isinstance(base_value, (list, set, tuple)):
+        result_list = []
+        task_list = []
+        for value in base_value:
+            replaced_value, value_task_list = _replace_task_args_with_refs(
+                value, task_graph_id)
+            result_list.append(replaced_value)
+            task_list.extend(value_task_list)
+        return type(base_value)(result_list), task_list
+    return base_value, []
+
+
 def _get_file_stats(
         base_value, hash_algorithm, ignore_list,
         ignore_directories):
@@ -1577,6 +1712,11 @@ def _get_file_stats(
         for value in base_value:
             for stat in _get_file_stats(
                     value, hash_algorithm, ignore_list, ignore_directories):
+                yield stat
+    elif isinstance(base_value, TaskRef):
+        for path in base_value.target_path_list:
+            for stat in _get_file_stats(
+                    path, hash_algorithm, ignore_list, ignore_directories):
                 yield stat
 
 
@@ -1650,10 +1790,12 @@ def _scrub_task_args(base_value, target_path_list):
 
     Returns:
         base_value with any functions replaced as strings and paths in
-            ``target_path_list`` with a 'target_path_list[n]' placeholder.
+        ``target_path_list`` with a 'target_path_list[n]' placeholder.
 
     """
-    if callable(base_value):
+    if isinstance(base_value, TaskRef):
+        return base_value._scrubbed_signature()
+    elif callable(base_value):
         try:
             if not hasattr(Task, 'func_source_map'):
                 Task.func_source_map = {}

--- a/src/taskgraph/Task.py
+++ b/src/taskgraph/Task.py
@@ -133,7 +133,12 @@ class TaskRef(object):
     """
 
     def __init__(self, task):
-        """Create a reference to ``task``."""
+        """Create a reference to ``task``.
+
+        Args:
+            task (Task): task to expose as a serializable reference.
+
+        """
         self.task_name = task.task_name
         self._task_id_hash = task._task_id_hash
         self._target_path_list = tuple(task._target_path_list)
@@ -145,11 +150,32 @@ class TaskRef(object):
 
     @property
     def target_path_list(self):
-        """Return a copy of the referenced task's target paths."""
+        """Return a copy of the referenced task's target paths.
+
+        Returns:
+            list[str]: normalized target paths from the referenced task.
+
+        """
         return list(self._target_path_list)
 
     def get(self, timeout=None):
-        """Return the referenced task result."""
+        """Return the referenced task result.
+
+        Args:
+            timeout (float): maximum number of seconds to wait when this
+                reference still points at a live parent-process ``Task``. This
+                is ignored after the reference has been serialized.
+
+        Returns:
+            value returned by the referenced task's callable.
+
+        Raises:
+            RuntimeError: if the task result was not serialized into this
+                reference.
+            ValueError: if the referenced task was not created with
+                ``store_result=True``.
+
+        """
         if not self._store_result:
             raise ValueError(
                 'must set `store_result` to True in `add_task` to invoke this '
@@ -163,14 +189,15 @@ class TaskRef(object):
 
     def _scrubbed_signature(self):
         """Return a stable representation for Task hashing."""
-        return (
-            'task_ref',
-            self._task_id_hash,
-            self._target_path_list,
-            self._store_result)
+        return ('task_ref', self._task_id_hash)
 
     def __getstate__(self):
-        """Serialize only portable task reference state."""
+        """Serialize only portable task reference state.
+
+        Returns:
+            dict: picklable state for this reference.
+
+        """
         state = {
             'task_name': self.task_name,
             '_task_id_hash': self._task_id_hash,
@@ -188,18 +215,31 @@ class TaskRef(object):
         return state
 
     def __setstate__(self, state):
-        """Restore serialized task reference state."""
+        """Restore serialized task reference state.
+
+        Args:
+            state (dict): state produced by ``__getstate__``.
+
+        """
         self.__dict__.update(state)
 
     def __eq__(self, other):
-        """Return True when ``other`` refers to the same task signature."""
+        """Return True when ``other`` refers to the same task signature.
+
+        Args:
+            other: object to compare against.
+
+        Returns:
+            bool: True if ``other`` refers to the same task signature.
+
+        """
         return (
             isinstance(other, self.__class__) and
             self._task_id_hash == other._task_id_hash)
 
     def __hash__(self):
         """Return a stable hash for set/dict membership."""
-        return hash(self._task_id_hash)
+        return int(self._task_id_hash, 16)
 
     def __repr__(self):
         """Return a debugging representation of this reference."""
@@ -833,12 +873,14 @@ class TaskGraph(object):
             if func is None:
                 func = _null_func
 
-            dependent_task_list = list(dependent_task_list)
-            args, args_task_list = _replace_task_args_with_refs(
+            args, args_dependency_task_list = _replace_task_args_with_refs(
                 args, self._task_graph_id)
-            kwargs, kwargs_task_list = _replace_task_args_with_refs(
+            kwargs, kwargs_dependency_task_list = _replace_task_args_with_refs(
                 kwargs, self._task_graph_id)
-            for task in args_task_list + kwargs_task_list:
+            # These lists contain the original Tasks; args/kwargs now contain
+            # TaskRefs that worker processes can serialize.
+            for task in (
+                    args_dependency_task_list + kwargs_dependency_task_list):
                 if task not in dependent_task_list:
                     dependent_task_list.append(task)
 
@@ -1618,33 +1660,54 @@ class Task(object):
 
 
 def _replace_task_args_with_refs(base_value, task_graph_id):
-    """Replace same-graph ``Task`` instances with ``TaskRef`` instances."""
+    """Replace same-graph ``Task`` values with serializable references.
+
+    Args:
+        base_value: value that may contain ``Task`` objects nested within
+            dictionaries, lists, sets, or tuples.
+        task_graph_id (str): unique identifier for the ``TaskGraph`` that is
+            accepting the argument value.
+
+    Returns:
+        tuple: ``(updated_value, dependency_task_list)`` where
+        ``updated_value`` has same-graph ``Task`` objects replaced with
+        ``TaskRef`` objects, and ``dependency_task_list`` contains the original
+        ``Task`` objects that should be added as dependencies.
+
+    Raises:
+        ValueError: if a ``Task`` argument belongs to a different
+            ``TaskGraph``.
+
+    """
     if isinstance(base_value, Task):
         if base_value._task_graph_id != task_graph_id:
             raise ValueError(
                 'Task arguments must come from the same TaskGraph as the '
                 'task being added')
         return TaskRef(base_value), [base_value]
+
+    def _replace_value_list(value_list):
+        """Replace nested task values and return collected dependencies."""
+        replaced_value_list = []
+        task_list = []
+        for value in value_list:
+            replaced_value, value_task_list = _replace_task_args_with_refs(
+                value, task_graph_id)
+            replaced_value_list.append(replaced_value)
+            task_list.extend(value_task_list)
+        return replaced_value_list, task_list
+
     if isinstance(base_value, dict):
         result_dict = {}
         task_list = []
         for key, value in base_value.items():
-            replaced_key, key_task_list = _replace_task_args_with_refs(
-                key, task_graph_id)
-            replaced_value, value_task_list = _replace_task_args_with_refs(
-                value, task_graph_id)
+            (replaced_key, replaced_value), pair_task_list = (
+                _replace_value_list((key, value)))
             result_dict[replaced_key] = replaced_value
-            task_list.extend(key_task_list)
-            task_list.extend(value_task_list)
+            task_list.extend(pair_task_list)
         return result_dict, task_list
     if isinstance(base_value, (list, set, tuple)):
-        result_list = []
-        task_list = []
-        for value in base_value:
-            replaced_value, value_task_list = _replace_task_args_with_refs(
-                value, task_graph_id)
-            result_list.append(replaced_value)
-            task_list.extend(value_task_list)
+        result_list, task_list = _replace_value_list(base_value)
         return type(base_value)(result_list), task_list
     return base_value, []
 
@@ -1682,6 +1745,9 @@ def _get_file_stats(
             ignored by the input parameters.
 
     """
+    if isinstance(base_value, TaskRef):
+        base_value = base_value.target_path_list
+
     if isinstance(base_value, _VALID_PATH_TYPES):
         try:
             norm_path = _normalize_path(base_value)
@@ -1712,11 +1778,6 @@ def _get_file_stats(
         for value in base_value:
             for stat in _get_file_stats(
                     value, hash_algorithm, ignore_list, ignore_directories):
-                yield stat
-    elif isinstance(base_value, TaskRef):
-        for path in base_value.target_path_list:
-            for stat in _get_file_stats(
-                    path, hash_algorithm, ignore_list, ignore_directories):
                 yield stat
 
 

--- a/src/taskgraph/__init__.py
+++ b/src/taskgraph/__init__.py
@@ -2,11 +2,13 @@
 from importlib.metadata import version
 from .Task import TaskGraph
 from .Task import Task
+from .Task import TaskRef
 from .Task import _TASKGRAPH_DATABASE_FILENAME
 
 __all__ = [
     'TaskGraph',
     'Task',
+    'TaskRef',
     '_TASKGRAPH_DATABASE_FILENAME'
 ]
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1514,7 +1514,11 @@ class TaskGraphTests(unittest.TestCase):
                     value = value_task.get()
 
             task_graph.close()
-            task_graph.join()
+            if iteration_id == 0:
+                task_graph.join()
+            else:
+                with self.assertRaises(RuntimeError):
+                    task_graph.join()
             task_graph = None
 
     def test_malformed_taskgraph_database(self):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1501,7 +1501,7 @@ class TaskGraphTests(unittest.TestCase):
                     transient_run=True,
                     store_result=True,
                     args=(expected_value,),
-                    task_name=f'first re-run transient')
+                    task_name='first re-run transient')
                 value = value_task.get()
                 self.assertEqual(value, expected_value)
             else:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,4 +1,5 @@
 """Tests for ecoshard.taskgraph."""
+import contextlib
 import hashlib
 import logging
 import logging.handlers
@@ -459,10 +460,10 @@ class TaskGraphTests(unittest.TestCase):
         # was a duplicate
         database_path = os.path.join(
             self.workspace_dir, ecoshard.taskgraph._TASKGRAPH_DATABASE_FILENAME)
-        with sqlite3.connect(database_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute("SELECT * FROM taskgraph_data")
-            result = cursor.fetchall()
+        with contextlib.closing(sqlite3.connect(database_path)) as conn:
+            with contextlib.closing(conn.cursor()) as cursor:
+                cursor.execute("SELECT * FROM taskgraph_data")
+                result = cursor.fetchall()
         self.assertEqual(len(result), 4)
 
     def test_task_broken_chain(self):
@@ -548,10 +549,10 @@ class TaskGraphTests(unittest.TestCase):
         # we shouldn't have anything in the database
         database_path = os.path.join(
             self.workspace_dir, ecoshard.taskgraph._TASKGRAPH_DATABASE_FILENAME)
-        with sqlite3.connect(database_path) as conn:
-            cursor = conn.cursor()
-            cursor.executescript("SELECT * FROM taskgraph_data")
-            result = cursor.fetchall()
+        with contextlib.closing(sqlite3.connect(database_path)) as conn:
+            with contextlib.closing(conn.cursor()) as cursor:
+                cursor.executescript("SELECT * FROM taskgraph_data")
+                result = cursor.fetchall()
         self.assertEqual(len(result), 0)
 
     def test_closed_graph(self):

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -289,10 +289,11 @@ class TaskGraphTests(unittest.TestCase):
         _ = task_graph.add_task(
             func=_long_running_function,
             args=(5,))
-        task_graph.close()
         timedout = not task_graph.join(0.5)
         # this should timeout since function runs for 5 seconds
         self.assertTrue(timedout)
+        task_graph.close()
+        task_graph.join()
 
     def test_precomputed_task(self):
         """TaskGraph: Test that a task reuses old results."""

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -30,6 +30,23 @@ def _return_value_once(value):
     return value
 
 
+def _return_value(value):
+    """Return the value passed to it."""
+    return value
+
+
+def _get_task_ref_value(task_ref):
+    """Return the result from a TaskRef."""
+    return task_ref.get()
+
+
+def _wait_for_file_then_return(value, wait_path):
+    """Wait for ``wait_path`` to exist, then return ``value``."""
+    while not os.path.exists(wait_path):
+        time.sleep(0.01)
+    return value
+
+
 def _noop_function(**kwargs):
     """Do nothing except allow kwargs to be passed."""
     pass
@@ -1366,6 +1383,87 @@ class TaskGraphTests(unittest.TestCase):
         expected_message = 'must set `store_result` to True in `add_task`'
         actual_message = str(cm.exception)
         self.assertTrue(expected_message in actual_message, actual_message)
+
+    def test_task_argument_get_multiprocessing(self):
+        """TaskGraph: Task args support ``get`` in process workers."""
+        task_graph = ecoshard.taskgraph.TaskGraph(
+            self.workspace_dir, 1, 0, parallel_mode='process')
+        try:
+            expected_value = 'task ref value'
+            value_task = task_graph.add_task(
+                func=_return_value,
+                args=(expected_value,),
+                store_result=True,
+                task_name='value task')
+            ref_task = task_graph.add_task(
+                func=_get_task_ref_value,
+                args=(value_task,),
+                store_result=True,
+                task_name='ref task')
+
+            self.assertEqual(ref_task.get(), expected_value)
+        finally:
+            task_graph.close()
+            task_graph.join()
+
+    def test_task_argument_creates_dependency(self):
+        """TaskGraph: Task args are automatically dependencies."""
+        task_graph = ecoshard.taskgraph.TaskGraph(self.workspace_dir, 0, 0)
+        wait_path = os.path.join(self.workspace_dir, 'release.txt')
+        expected_value = 'dependency value'
+        value_task = task_graph.add_task(
+            func=_wait_for_file_then_return,
+            args=(expected_value, wait_path),
+            store_result=True,
+            task_name='blocked value task')
+        ref_task = task_graph.add_task(
+            func=_get_task_ref_value,
+            args=(value_task,),
+            store_result=True,
+            task_name='dependent ref task')
+
+        try:
+            self.assertIn(ref_task.task_name, task_graph._dependent_task_map)
+            self.assertIn(
+                value_task.task_name,
+                task_graph._dependent_task_map[ref_task.task_name])
+            with open(wait_path, 'w') as wait_file:
+                wait_file.write('ready')
+            self.assertEqual(ref_task.get(), expected_value)
+        finally:
+            if not os.path.exists(wait_path):
+                with open(wait_path, 'w') as wait_file:
+                    wait_file.write('ready')
+            task_graph.close()
+            task_graph.join()
+
+    def test_task_argument_from_different_taskgraph_raises(self):
+        """TaskGraph: Task args must come from the same TaskGraph."""
+        task_graph = ecoshard.taskgraph.TaskGraph(self.workspace_dir, 0)
+        other_workspace_dir = tempfile.mkdtemp(dir=self.workspace_dir)
+        other_task_graph = ecoshard.taskgraph.TaskGraph(
+            other_workspace_dir, 0)
+        try:
+            value_task = task_graph.add_task(
+                func=_return_value,
+                args=('value',),
+                store_result=True,
+                task_name='value task')
+            with self.assertRaises(ValueError) as cm:
+                other_task_graph.add_task(
+                    func=_get_task_ref_value,
+                    args=(value_task,),
+                    store_result=True,
+                    task_name='invalid ref task')
+            expected_message = 'same TaskGraph'
+            actual_message = str(cm.exception)
+            self.assertTrue(
+                expected_message in actual_message, actual_message)
+        finally:
+            task_graph.close()
+            task_graph.join()
+            other_task_graph.close()
+            other_task_graph.join()
 
     def test_return_value(self):
         """TaskGraph: test that ``.get`` behavior works as expected."""


### PR DESCRIPTION
Closes #44

## Summary
- Add a serializable `TaskRef` wrapper for same-graph `Task` arguments.
- Convert `Task` values found in `add_task` args/kwargs into `TaskRef` instances and automatically register them as dependencies.
- Allow worker functions to call `.get()` on the received reference when the upstream task used `store_result=True`.
- Add TaskGraph tests for process-worker `.get()`, automatic dependency registration, and rejecting tasks from another TaskGraph.
- Add `environment.yml`, declare package/test dependencies in `pyproject.toml`, and move static package metadata out of `setup.py` so local test setup is explicit.
- Explicitly close sqlite cursors/connections in TaskGraph test DB assertions so Windows teardown can delete the temporary workspace.
- Update `test_return_value` to expect `TaskGraph.join()` to re-raise the task exception after `.get()` observes an intentional task failure.
- Update `test_timeout_task` to check `join(timeout)` before `close()` waits for executor shutdown.

## Testing
- `python -m py_compile src\taskgraph\Task.py src\taskgraph\__init__.py tests\test_task.py`
- `git diff --check`
- Temporary process-mode smoke check for passing a task argument and calling `.get()` in the worker.
- `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb')); print('pyproject ok')"`
- `python -m py_compile setup.py`
- Tiny sqlite repro verified that `contextlib.closing(sqlite3.connect(...))` releases the DB file before `shutil.rmtree` on Windows.
- `python -m unittest tests.test_task.TaskGraphTests.test_task_argument_get_multiprocessing tests.test_task.TaskGraphTests.test_task_argument_creates_dependency tests.test_task.TaskGraphTests.test_task_argument_from_different_taskgraph_raises` could not run in the earlier local environment because `retrying` was not installed before the test module imports.

## Notes
- `mamba env update -n geopy311 -f environment.yml` successfully installed the conda packages in the user's env, then failed in the pip editable-install step because the earlier partial `[project]` table conflicted with metadata still declared in `setup.py`. The latest packaging commits move that static metadata into `pyproject.toml`, leave `setup.py` focused on extension/package layout, and remove the superseded license classifier.