### PR TITLE
Remove empty raster stats warning

### DIFF
--- a/src/ecoshard/geoprocessing/geoprocessing_core.pyx
+++ b/src/ecoshard/geoprocessing/geoprocessing_core.pyx
@@ -1056,8 +1056,6 @@ def stats_worker(stats_work_queue):
             (min_value, max_value, M_local,
                 (S_local / <double>n) ** 0.5))
     else:
-        LOGGER.warning(
-            "No valid pixels were received, sending None.")
         stats_work_queue.put(None)
 
 


### PR DESCRIPTION
## Summary
- Remove the warning emitted by `geoprocessing_core.stats_worker` when no valid pixels are available for raster statistics.
- Preserve the existing behavior of returning `None` so callers skip setting statistics for all-nodata or non-finite outputs.

## Related Issue
Closes #52

## Testing
- `rg -n "No valid pixels were received|sending None" src\ecoshard\geoprocessing\geoprocessing_core.pyx src\ecoshard\geoprocessing\geoprocessing.py`
- `git diff --check -- src\ecoshard\geoprocessing\geoprocessing_core.pyx`

## Notes
- Full runtime tests were not run here because this is a `.pyx` change and requires the compiled geoprocessing extension environment.